### PR TITLE
Revert "LineageParts: Update the way OMS records details about overlays"

### DIFF
--- a/src/org/lineageos/lineageparts/style/util/OverlayManager.java
+++ b/src/org/lineageos/lineageparts/style/util/OverlayManager.java
@@ -54,7 +54,7 @@ public class OverlayManager {
     private boolean isChangeableOverlay(@NonNull String pkg) {
         try {
             PackageInfo pi = mPackageManager.getPackageInfo(pkg, 0);
-            return pi != null && (pi.overlayFlags & PackageInfo.FLAG_OVERLAY_STATIC) == 0;
+            return pi != null && !pi.isStaticOverlay;
         } catch (PackageManager.NameNotFoundException e) {
             return false;
         }


### PR DESCRIPTION
This partially reverts commit 75d5b99b7072525378abcd6890240b884c562a72.

Reverting only the OverlayManager part, as we've reverted the frameworks part of it for substratum to work properly

Signed-off-by: Akhil Narang <akhilnarang.1999@gmail.com>